### PR TITLE
Upgraded iPizza gem to support new iPizza providers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ipizza-rails.gemspec
 gemspec

--- a/README.markdown
+++ b/README.markdown
@@ -1,9 +1,11 @@
-Adds iPizza support to Rails 3 applications. Provides rails generators and easy configuration loading.
+Adds iPizza support to Rails 3+ applications. Provides rails generators and easy configuration loading.
+
+Read more about supported providers and configuration options form [ipizza gem hompage](https://github.com/Voog/ipizza).
 
 Installation
 ------------
 
-In your Gemfile add ipizza-rails gem:
+In your `Gemfile` add `ipizza-rails` gem:
 
     gem ipizza-rails
 

--- a/ipizza-rails.gemspec
+++ b/ipizza-rails.gemspec
@@ -8,17 +8,16 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Priit Haamer']
   s.email       = ['priit@fraktal.ee']
-  s.homepage    = "http://rubygems.org/gems/ipizza-rails"
+  s.homepage    = "https://github.com/Voog/ipizza-rails"
   s.summary     = %q{Adds iPizza support to Rails applications}
   s.description = %q{Helpers to use iPizza inside Rails applications}
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
   
-  s.add_dependency(%q<ipizza>, ['>= 1.0.0'])
+  s.add_dependency 'ipizza', '>= 2.0.0'
   
-  s.add_development_dependency('rspec', ['>= 2.9.0'])
-  s.add_development_dependency('rake')
+  s.add_development_dependency 'rspec', '>= 2.9.0'
+  s.add_development_dependency 'rake'
 end

--- a/lib/ipizza-rails/form_helpers.rb
+++ b/lib/ipizza-rails/form_helpers.rb
@@ -3,13 +3,15 @@ module Ipizza
     module FormHelpers
       def ipizza_payment_form_tag(payment, options = {}, &block)
         request = case options.delete(:service).to_sym
+        when :lhv
+          Ipizza::Provider::Lhv.new.payment_request(payment)
         when :swedbank
           Ipizza::Provider::Swedbank.new.payment_request(payment)
         when :seb
           Ipizza::Provider::Seb.new.payment_request(payment)
         when :sampo
           Ipizza::Provider::Sampo.new.payment_request(payment)
-        when :nordea
+        when :nordea, :danske
           Ipizza::Provider::Nordea.new.payment_request(payment)
         when :krediidipank
           Ipizza::Provider::Krediidipank.new.payment_request(payment)

--- a/lib/ipizza-rails/generator/templates/ipizza.yml
+++ b/lib/ipizza-rails/generator/templates/ipizza.yml
@@ -1,4 +1,25 @@
 development:
+  lhv:
+    service_url: https://lhv.ee/banklink
+    return_url: http://localhost:3000/lhv/return
+    cancel_url: http://localhost:3000/lhv/cancel
+    login: dealer
+    file_cert: seb_test_pub.pem
+    file_key: seb_test_priv.pem
+    encoding: UTF-8
+    snd_id: testvpos
+
+  sampo:
+    service_url: https://www2.danskebank.ee/ibank/pizza/pizza
+    return_url: http://localhost:3000/sampo
+    cancel_url: http://localhost:3000/sampo
+    login: dealer
+    file_cert: seb_test_pub.pem
+    file_key: seb_test_priv.pem
+    key_secret: foobar
+    encoding: UTF-8
+    snd_id: sender
+
   swedbank:
     service_url: https://www.swedbank.ee/banklink
     return_url: http://localhost:3000/swedbank/return
@@ -42,6 +63,27 @@ development:
     snd_id: testvpos
 
 test:
+  lhv:
+    service_url: https://lhv.ee/banklink
+    return_url: http://test.host:3000/lhv/return
+    cancel_url: http://test.host:3000/lhv/cancel
+    login: dealer
+    file_cert: seb_test_pub.pem
+    file_key: seb_test_priv.pem
+    encoding: UTF-8
+    snd_id: testvpos
+
+  sampo:
+    service_url: https://www2.danskebank.ee/ibank/pizza/pizza
+    return_url: http://test.host/sampo
+    cancel_url: http://test.host/sampo
+    login: dealer
+    file_cert: seb_test_pub.pem
+    file_key: seb_test_priv.pem
+    key_secret: foobar
+    encoding: UTF-8
+    snd_id: sender
+
   swedbank:
     service_url: https://www.swedbank.ee/banklink
     return_url: http://test.host/swedbank/return
@@ -85,6 +127,27 @@ test:
     snd_id: testvpos
 
 production:
+  lhv:
+    service_url: https://lhv.ee/banklink
+    return_url: http://myapp.host/lhv/return
+    cancel_url: http://myapp.host/lhv/cancel
+    login: dealer
+    file_cert: seb_test_pub.pem
+    file_key: seb_test_priv.pem
+    encoding: UTF-8
+    snd_id: testvpos
+
+  sampo:
+    service_url: https://www2.danskebank.ee/ibank/pizza/pizza
+    return_url: http://myapp.host/sampo
+    cancel_url: http://myapp.host/sampo
+    login: dealer
+    file_cert: seb_test_pub.pem
+    file_key: seb_test_priv.pem
+    key_secret: foobar
+    encoding: UTF-8
+    snd_id: sender
+
   swedbank:
     service_url: https://www.swedbank.ee/banklink
     return_url: http://myapp.host/swedbank/return

--- a/lib/ipizza-rails/version.rb
+++ b/lib/ipizza-rails/version.rb
@@ -1,5 +1,5 @@
 module Ipizza
   module Rails
-    VERSION = '1.0.0'
+    VERSION = '2.0.0'
   end
 end


### PR DESCRIPTION
- Upgraded iPizza gem to v2.0.0
- It adds support for iPizza services (`1011`, `1012`, `4011` and `4012`)
- It removes support for iPizza services (`1001`, `1002`, `4001` and `4002`)
- Added new provider: LHV Bank
- Added LHV and Sampo Bank configuration examples to config init file
