### PR TITLE
Support ERB syntax in ipizza.yml configuration file

### DIFF
--- a/lib/ipizza-rails/railtie.rb
+++ b/lib/ipizza-rails/railtie.rb
@@ -1,5 +1,6 @@
 require 'ipizza'
 require 'rails'
+require "erb"
 
 require 'ipizza-rails/form_helpers'
 
@@ -14,7 +15,7 @@ class Ipizza::Rails::Railtie < ::Rails::Railtie
     if File.exist?(Rails.root.join('config', 'ipizza.yml'))
       Ipizza::Config.configure do |c|
         c.certs_root = Rails.root.join('config', 'certificates')
-        c.load_from_hash(YAML::load_file(Rails.root.join('config', 'ipizza.yml')).fetch(Rails.env))
+        c.load_from_hash(YAML::load(ERB.new(Rails.root.join('config', 'ipizza.yml').read).result).fetch(Rails.env))
       end
     end
   end

--- a/lib/ipizza-rails/version.rb
+++ b/lib/ipizza-rails/version.rb
@@ -1,5 +1,5 @@
 module Ipizza
   module Rails
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end


### PR DESCRIPTION
Example:

```
production:
  seb:
    service_url: https://www.seb.ee/cgi-bin/unet3.sh/un3min.r
    return_url: <%= ENV['IPIZZA_RETURN_HOST'] %>/seb/return
    cancel_url: <%= ENV['IPIZZA_RETURN_HOST'] %>/seb/cancel
    login: <%= ENV['IPIZZA_SEB_LOGIN'] %>
    file_cert: <%= ENV['IPIZZA_SEB_CERT_PATH'] %>
    file_key: <%= ENV['IPIZZA_SEB_KEY_PATH'] %>
    encoding: <%= ENV['IPIZZA_SEB_ENCODING'] %>
    snd_id: <%= ENV['IPIZZA_SEB_SND_ID'] %>
```
